### PR TITLE
Build Docker image from local source instead of PyPI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ./rdm/init_files
+          context: .
           file: ./rdm/init_files/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/rdm/init_files/Dockerfile
+++ b/rdm/init_files/Dockerfile
@@ -62,8 +62,13 @@ RUN mkdir -p /usr/share/fonts/jetbrains-mono && \
 # Verify installations
 RUN pandoc --version && typst --version
 
-# Install RDM
-RUN pip install --no-cache-dir --break-system-packages rdm
+# Install RDM from local source using uv
+COPY . /tmp/rdm
+RUN pip install --no-cache-dir --break-system-packages uv && \
+    uv build --wheel --out-dir /tmp/rdm/dist /tmp/rdm && \
+    pip install --no-cache-dir --break-system-packages /tmp/rdm/dist/*.whl && \
+    pip uninstall -y uv && \
+    rm -rf /tmp/rdm
 
 WORKDIR /dhf
 


### PR DESCRIPTION
- Add .dockerignore to exclude .git, .venv, tests, etc.
- Update Dockerfile to install rdm from local source
- Change build context to repo root