### PR TITLE
feat(story-audit): add STRIDE risk schema support v1.1.0-alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rdm"
-version = "1.0.1-alpha"
+version = "1.1.0-alpha"
 description = "Regulatory Documentation Manager"
 readme = "README.md"
 license = {text = "MIT"}
@@ -33,8 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 github = ["pygithub==2.6.1"]
-story = ["pydantic==2.12.5"]
-analytics = ["pydantic==2.12.5", "duckdb==1.4.3"]
+story-audit = ["pydantic==2.12.5", "duckdb==1.4.3"]
 dev = [
     "pytest==9.0.2",
     "ruff==0.9.6",

--- a/rdm/main.py
+++ b/rdm/main.py
@@ -98,7 +98,7 @@ def handle_story_command(args):
 
     except ImportError as e:
         print(f"Error: Missing dependency for story_audit: {e}")
-        print("Install with: pip install rdm[story]")
+        print("Install with: pip install rdm[story-audit]")
         return 1
 
 

--- a/rdm/story_audit/validate.py
+++ b/rdm/story_audit/validate.py
@@ -17,7 +17,7 @@ try:
     from pydantic import ValidationError
 except ImportError as e:
     raise ImportError(
-        f"Missing dependency: {e}. Install with: pip install rdm[story]"
+        f"Missing dependency: {e}. Install with: pip install rdm[story-audit]"
     )
 
 from rdm.story_audit.schema import (

--- a/rdm/version.py
+++ b/rdm/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0'
+__version__ = '1.1.0-alpha'

--- a/uv.lock
+++ b/uv.lock
@@ -1025,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "rdm"
-version = "1.0.1a0"
+version = "1.1.0a0"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
@@ -1034,10 +1034,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-analytics = [
-    { name = "duckdb" },
-    { name = "pydantic" },
-]
 dev = [
     { name = "check-manifest" },
     { name = "coverage" },
@@ -1053,7 +1049,8 @@ dev = [
 github = [
     { name = "pygithub" },
 ]
-story = [
+story-audit = [
+    { name = "duckdb" },
     { name = "pydantic" },
 ]
 
@@ -1062,14 +1059,13 @@ requires-dist = [
     { name = "check-manifest", marker = "extra == 'dev'", specifier = "==0.51" },
     { name = "coverage", marker = "extra == 'dev'", specifier = "==7.13.1" },
     { name = "docutils", marker = "extra == 'dev'", specifier = "==0.21.2" },
-    { name = "duckdb", marker = "extra == 'analytics'", specifier = "==1.4.3" },
     { name = "duckdb", marker = "extra == 'dev'", specifier = "==1.4.3" },
+    { name = "duckdb", marker = "extra == 'story-audit'", specifier = "==1.4.3" },
     { name = "gitpython", specifier = "==3.1.46" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "mock", marker = "extra == 'dev'", specifier = "==5.2.0" },
-    { name = "pydantic", marker = "extra == 'analytics'", specifier = "==2.12.5" },
     { name = "pydantic", marker = "extra == 'dev'", specifier = "==2.12.5" },
-    { name = "pydantic", marker = "extra == 'story'", specifier = "==2.12.5" },
+    { name = "pydantic", marker = "extra == 'story-audit'", specifier = "==2.12.5" },
     { name = "pygithub", marker = "extra == 'github'", specifier = "==2.6.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
@@ -1077,7 +1073,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'", specifier = "==8.1.3" },
     { name = "sphinx-autobuild", marker = "extra == 'dev'", specifier = "==2024.10.3" },
 ]
-provides-extras = ["github", "story", "analytics", "dev"]
+provides-extras = ["github", "story-audit", "dev"]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
## Summary

- Add STRIDE-based risk schema with cluster organization (RiskCluster, Risk, RiskControl, RiskMitigation, RiskAcceptance models)
- Support hazard/situation/harm chain with severity × probability scoring matrix
- New ID formats: `RISK-CLUSTER-NNN` (e.g., RISK-IAM-001) and `RC-XXX` for clusters
- AC-level traceability via `ac_refs` field (US-XXX:AC-XXX format)
- Sync creates `risk_clusters`, `risks`, `risk_controls` tables in DuckDB
- Combine `story` + `analytics` extras into single `story-audit` extra

## Test plan

- [x] All 28 story_audit tests pass
- [x] Ruff check passes
- [x] Successfully synced halla-health-infra risk files (12 risks, 38 controls, 6 clusters)
- [x] Manual verification of DuckDB output

🤖 Generated with [Claude Code](https://claude.com/claude-code)